### PR TITLE
fix toml example

### DIFF
--- a/content/blog/getting-started-with-v.md
+++ b/content/blog/getting-started-with-v.md
@@ -103,7 +103,7 @@ Truncated
 '
 
 fn main() {
-	doc := toml.parse(toml_text) or { panic(err) }
+	doc := toml.parse_text(toml_text) or { panic(err) }
 	title := doc.value('title').string()
 	println('title: "$title"')
 	ip := doc.value('servers.alpha.ip').string()


### PR DESCRIPTION
v says that the function `toml.parse` has been deprecated since 2022-06-18. Example should use `toml.parse_text`.